### PR TITLE
Add parchment background support

### DIFF
--- a/DungeonGenerator.py
+++ b/DungeonGenerator.py
@@ -1,7 +1,14 @@
-import random, math
+import random, math, os
 from Display import *
 game = True
 room_type = ['Hall', 'Cave', 'Bedroom', 'Dining Room', 'Cellar']
+
+parchment_path = os.path.join("images", "textures", "parchment.jpg")
+if os.path.exists(parchment_path):
+    parchment = pygame.image.load(parchment_path).convert()
+    parchment = pygame.transform.scale(parchment, (X, Y))
+else:
+    parchment = None
 
 class Direction2D:
 
@@ -215,7 +222,10 @@ def main():
             greytiles.draw(display_surface, index, new_x, new_y)
             print(index)'''
 
-        display_surface.fill(black)
+        if parchment:
+            display_surface.blit(parchment, (0, 0))
+        else:
+            display_surface.fill((222, 184, 135))
         dungeon.draw_dungeon()
 
             #pygame.display.flip()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Dungeon Generator
+
+### Assets
+- Add a parchment texture at: `./images/textures/parchment.jpg`
+- Recommended size: 1920x1080 (it will be auto-scaled).
+- If the file is missing, the generator will use a beige background instead.


### PR DESCRIPTION
## Summary
- load an optional parchment texture for the dungeon background and fall back to beige when missing
- document the parchment asset requirements in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f7077ec08331929d1b94d03c52f1