### PR TITLE
Add translucent watercolor room fill

### DIFF
--- a/DungeonGenerator.py
+++ b/DungeonGenerator.py
@@ -2,6 +2,7 @@ import random, math, os
 from Display import *
 
 INK_BROWN = (80, 40, 20)
+ROOM_FILL = (210, 180, 140, 80)  # light beige with transparency
 
 
 def draw_wall_sketch(surface, x1, y1, x2, y2):
@@ -16,6 +17,19 @@ def draw_wall_sketch(surface, x1, y1, x2, y2):
         (x2 + offset(), y2 + offset()),
         2,
     )
+
+
+def draw_room_fill(surface, room):
+    """Fill a room with a translucent beige color for a watercolor effect."""
+    rect = pygame.Rect(
+        room.x * tilesize,
+        room.y * tilesize,
+        room.width * tilesize,
+        room.height * tilesize,
+    )
+    s = pygame.Surface((rect.width, rect.height), pygame.SRCALPHA)
+    s.fill(ROOM_FILL)
+    surface.blit(s, rect.topleft)
 
 
 game = True
@@ -129,6 +143,7 @@ class Room:
 
 
     def draw(self):
+        draw_room_fill(display_surface, self)
         self.walls[0].draw_wall1()
         self.walls[1].draw_wall2()
         self.walls[2].draw_wall3()


### PR DESCRIPTION
## Summary
- introduce a reusable room fill color constant to support translucent shading
- add a helper that draws a semi-transparent beige overlay sized to each room
- call the room fill helper before sketching walls to create an aquarelle effect

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f827b4cc8331b5c04b53912cadc6