### PR TITLE
Add optional fantasy icons to room rendering

### DIFF
--- a/DungeonGenerator.py
+++ b/DungeonGenerator.py
@@ -4,6 +4,19 @@ from Display import *
 INK_BROWN = (80, 40, 20)
 ROOM_FILL = (210, 180, 140, 80)  # light beige with transparency
 
+icon_paths = {
+    "chest": os.path.join("images", "icons", "chest.png"),
+    "trap": os.path.join("images", "icons", "trap.png"),
+    "torch": os.path.join("images", "icons", "torch.png"),
+    "monster": os.path.join("images", "icons", "monster.png"),
+}
+icons = {}
+for name, path in icon_paths.items():
+    if os.path.exists(path):
+        icons[name] = pygame.image.load(path).convert_alpha()
+    else:
+        icons[name] = None
+
 
 def draw_wall_sketch(surface, x1, y1, x2, y2):
     """Draw a slightly irregular brown line for walls."""
@@ -30,6 +43,30 @@ def draw_room_fill(surface, room):
     s = pygame.Surface((rect.width, rect.height), pygame.SRCALPHA)
     s.fill(ROOM_FILL)
     surface.blit(s, rect.topleft)
+
+
+def draw_room_icons(surface, room):
+    """Randomly place decorative icons in rooms if assets are available."""
+    import random
+
+    choices = []
+    if icons["chest"]:
+        choices.append("chest")
+    if icons["trap"]:
+        choices.append("trap")
+    if icons["torch"]:
+        choices.append("torch")
+    if icons["monster"]:
+        choices.append("monster")
+
+    if choices:
+        selected = random.choice(choices)
+        icon = icons[selected]
+        if icon:
+            # place roughly at the center of the room
+            x = room.center_x - icon.get_width() // 2
+            y = room.center_y - icon.get_height() // 2
+            surface.blit(icon, (x, y))
 
 
 game = True
@@ -148,6 +185,7 @@ class Room:
         self.walls[1].draw_wall2()
         self.walls[2].draw_wall3()
         self.walls[3].draw_wall4()
+        draw_room_icons(display_surface, self)
 
     def draw_red(self):
         for wall in self.walls:

--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@
 - Add a parchment texture at: `./images/textures/parchment.jpg`
 - Recommended size: 1920x1080 (it will be auto-scaled).
 - If the file is missing, the generator will use a beige background instead.
+
+### Icons
+Optional icons can be placed in `./images/icons/`:
+- chest.png → treasure chests
+- trap.png → traps
+- torch.png → torches
+- monster.png → monsters
+If missing, the dungeon will still render without errors.


### PR DESCRIPTION
## Summary
- load optional chest, trap, torch, and monster icons when assets are available
- render a randomly selected icon in each room after drawing its walls
- document the optional icon assets in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f895a08c8331add78e56d8027549